### PR TITLE
Kodama & Ruby-binlog errors are logged with the whole event + indication...

### DIFF
--- a/lib/fluent/plugin/in_mysql_binlog.rb
+++ b/lib/fluent/plugin/in_mysql_binlog.rb
@@ -83,15 +83,15 @@ module Fluent
       class << self
         def to_hash(event)
           event_hash = {}
+          event_hash["errors"] = {}
           attributes_for(event).map do |attr|
             begin
               event_hash[attr] = event.send(attr.to_sym)
-              event_hash[attr + '_is_error'] = false
             rescue => e
               require 'json'
-              event_hash[attr] = e.inspect + "\n" + e.backtrace.join("\n")
-              event_hash[attr + '_is_error'] = true
-              $log.error event_hash.to_json
+              event_hash[attr] = ""
+              event_hash["errors"][attr] = e.inspect + "\n" + e.backtrace.join("\n")              
+              $log.error "Error occured in the following mysql event:\n" + event_hash.to_json
             end
           end
           event_hash

--- a/lib/fluent/plugin/in_mysql_binlog.rb
+++ b/lib/fluent/plugin/in_mysql_binlog.rb
@@ -83,17 +83,23 @@ module Fluent
       class << self
         def to_hash(event)
           event_hash = {}
-          event_hash["errors"] = {}
+          errors = {}
           attributes_for(event).map do |attr|
             begin
               event_hash[attr] = event.send(attr.to_sym)
             rescue => e
-              require 'json'
               event_hash[attr] = ""
-              event_hash["errors"][attr] = e.inspect + "\n" + e.backtrace.join("\n")              
-              $log.error "Error occured in the following mysql event:\n" + event_hash.to_json
+              errors[attr] = e.inspect + "\n" + e.backtrace.join("\n")                            
             end
           end
+
+          # Add and log errors
+          unless errors.empty?
+            require 'json'
+            event_hash["errors"] = errors
+            $log.error "Error occured in the following mysql event:\n" + event_hash.to_json
+          end          
+
           event_hash
         end
 


### PR DESCRIPTION
I have encountered an issue that a method in ruby-binlog is throwing an exception when trying to set ruby DateTime objects.
Those errors are not shown by default and all is see is an error that expected array but got nil.

The following code adds:
1. When a method using send fails, the whole event is logged with the error message instead the send output.
2. Error message is populated into the hash in place of the attribute type output.
3. Indicator in the event emitted if any of the attributes is failed.

This adds visibility and debugging ability in the case described.
